### PR TITLE
Fix warnings with Wall and Wextra

### DIFF
--- a/InstrumentingProfiler.cpp
+++ b/InstrumentingProfiler.cpp
@@ -189,6 +189,16 @@ namespace SysprogsInstrumentingProfiler
 			{
 				sd_nvic_critical_region_exit(m_Nested);
 			}
+#else
+		public:
+			// Empty constructor and deconstructor are needed to suppress "Unused variable" warning
+			VendorSpecificInterruptHolderRAII()
+			{
+			}
+
+			~VendorSpecificInterruptHolderRAII()
+			{
+			}
 #endif
 		};
 	} // namespace VendorSpecificWorkarounds
@@ -646,8 +656,8 @@ extern "C" __attribute__((naked)) void SysprogsStackVerifierHook()
 	asm("ldr r0, =_ZN21SysprogsStackVerifier10StackLimitE");
 	asm("ldr r0, [r0]");
 	asm("add r0, r1");
-	asm("cmp r0, sp");
-	asm("bls StackVerifierHook_Exit");
+	asm("cmp sp, r0");
+	asm("bhi StackVerifierHook_Exit");
 	asm("ldr r0, [sp, #4]");
 	asm("mov lr, r0");
 	asm("ldr r0, [sp, #12]");

--- a/ProfilerRTOS_FreeRTOS.c
+++ b/ProfilerRTOS_FreeRTOS.c
@@ -4,7 +4,7 @@
 #include "SysprogsProfilerInterface.h"
 
 //Using those macros in conjunction with the <DebugInfoBinding> tag allows accessing fields of private structures not exposed via FreeRTOS headers.
-#define DELAYED_STRUCT_MEMBER_OFFSET(struct, member) const volatile int __attribute__((section(".text." #struct "_" #member "_Offset"))) struct##_##member##_Offset;
+#define DELAYED_STRUCT_MEMBER_OFFSET(struct, member) const volatile int __attribute__((section(".text." #struct "_" #member "_Offset"))) struct##_##member##_Offset
 #define STRUCT_MEMBER(ptr, result_type, structType, member) (*((result_type *)((char *)ptr + structType##_##member##_Offset)))
 
 DELAYED_STRUCT_MEMBER_OFFSET(tskTaskControlBlock, pcTaskName);
@@ -93,15 +93,17 @@ struct
 
 void __attribute__((noinline, optimize("-O0"))) SysprogsRTOSHooks_FreeRTOS_traceQUEUE_SEND(void *pQueue)
 {
+	(void)pQueue;
 	__asm("nop");
 }
 
 void __attribute__((noinline, optimize("-O0"))) SysprogsRTOSHooks_FreeRTOS_traceQUEUE_RECEIVE(void *pQueue)
 {
+	(void)pQueue;
 	__asm("nop");
 }
 
-void __attribute__((noinline, optimize("-O0"))) SysprogsRTOSHooks_FreeRTOS_SchedulerStarting()
+void __attribute__((noinline, optimize("-O0"))) SysprogsRTOSHooks_FreeRTOS_SchedulerStarting(void)
 {
 	__asm("bkpt 255"); //When this breakpoint triggers, VisualGDB will automatically reparse real-time watch expressions that could not be parsed before
 	vTaskStartScheduler();

--- a/SamplingProfiler.cpp
+++ b/SamplingProfiler.cpp
@@ -238,7 +238,10 @@ extern "C" void SysprogsProfiler_ProcessSample(void *PC, void *SP, void *FP, voi
 			}
 
 			if (newRate > 100 && newRate < 100000)
-				g_SamplingProfilerRate = g_SamplingProfilerAutoRate = newRate;
+			{
+				g_SamplingProfilerAutoRate = newRate;
+				g_SamplingProfilerRate = newRate;
+			}
 		}
 		s_PacketsDropped = 0;
 		s_PacketsInCycle = 0;

--- a/SmallNumberCoder.h
+++ b/SmallNumberCoder.h
@@ -10,16 +10,15 @@ private:
 	void *m_RefPointA, *m_RefPointB;
 
 private:
-	static inline int IsSignedIntConstrained(int value, int bits)
+	static inline int IsSignedIntConstrained(int value, unsigned bits)
 	{
-		int mask = -1 << bits;
-		int refVal = ~(((value >> (bits - 1)) & 1) - 1);
-		return (value & mask) == (refVal & mask);
+		unsigned mask = (~(unsigned)0) << (bits - 1);
+		return ((value & mask) == 0) || ((value & mask) == mask);
 	}
 
-	static inline int IsUnsignedIntConstrained(unsigned value, int bits)
+	static inline int IsUnsignedIntConstrained(unsigned value, unsigned bits)
 	{
-		int mask = -1 << bits;
+		unsigned mask = (~(unsigned)0) << bits;
 		return (value & mask) == 0;
 	}
 
@@ -107,7 +106,7 @@ public:
 
 	inline bool WriteSmallMostLikelyEvenSInt(int value)
 	{
-		int signBit = (value >> 31) & 1;
+		int signBit = (value & 0x80000000) >> 31;
 		int permutatedValue = (int)((value & 0xffff0000) | ((value & 0xffff) >> 1) | (((value & 1) ^ signBit) << 15));
 
 		if (IsSignedIntConstrained(permutatedValue, 15))
@@ -277,9 +276,11 @@ private:
 	char *m_RefPointA, *m_RefPointB;
 
 private:
-	static int SignExtend(int value, int bits)
+	static int SignExtend(int value, unsigned bits)
 	{
-		return ((~(((value >> (bits - 1)) & 1) - 1)) << bits) | value;
+		unsigned signbit = 1u << (bits - 1);
+		unsigned signpad = (~(unsigned)0) << bits;
+		return (value & signbit) ? (value | signpad) : value;
 	}
 
 	inline unsigned PeekInt32(int delta = 0)
@@ -388,7 +389,7 @@ public:
 			m_Offset += 5;
 		}
 
-		int signBit = (permutatedValue >> 31) & 1;
+		int signBit = (permutatedValue & 0x80000000) >> 31;
 		*pValue = (int)(((unsigned)permutatedValue & 0xffff0000) | ((((unsigned)permutatedValue & 0x8000) >> 15) ^ signBit) | (((unsigned)permutatedValue & 0x7fff) << 1));
 		return true;
 	}

--- a/TestResourceManager.cpp
+++ b/TestResourceManager.cpp
@@ -300,6 +300,7 @@ extern "C" size_t __read(int fd, const unsigned char *pBuffer, size_t size)
 extern "C" int _read(int fd, char *pBuffer, int size)
 #endif
 {
+	(void)fd;
 	return TRMReadStdin((void *)pBuffer, size, 1);
 }
 #endif


### PR DESCRIPTION
Related forum topic:
https://sysprogs.com/w/forums/topic/warnings-with-wall-and-wextra/
I'm not sure if it works.... Profiler and tracing are unstable on my machine...(even with original code...)

Reason for the change:
- InstrumentingProfiler.cpp:
Unused variable will be flagged if the class doesn't have a explicit constructor and destructor
sp used as second operand is deprecated
- ProfilerRTOS_FreeRTOS.c:
ISO C does not allow extra ';' outside of a function 
a ";" is added when using the macro DELAYED_STRUCT_MEMBER_OFFSET, so the macro itself doesn't need ";"
void is needed to show that the function doesn't have any parameter
- SamplingProfiler.cpp:
using value of assignment with 'volatile'-qualified left operand is deprecated
- SmallNumberCoder.h
shifting a negative value is technically undefined behavior